### PR TITLE
Correct variable name in getInteractions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ const blockchainStats = async () => {
 Returns on which chain address was interacting.
 
 ```javascript
-const blockchainStats = async () => {
+const interactions = async () => {
   return await provider.getInteractions({
       address: '0xF977814e90dA44bFA03b6295A0616a897441aceC',
   });


### PR DESCRIPTION
### Change in code:
**-const blockchainStats = async () => {
   +const interactions = async () => {**

> The variable was changed from blockchainStats to interactions to match the data returned from the getInteractions() method.
This change also prevents potential errors:
-Avoids confusion with the getBlockchainStats method
-Prevents incorrect usage of returned data
