### PR TITLE
fix: rename `GetTransfersRequest` to `GetTokenTransfersRequest`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -306,7 +306,7 @@ export interface GetTokenTransfersReply {
     transfers: TokenTransfer[];
     syncStatus?: SyncStatus;
 }
-export interface GetTransfersRequest {
+export interface GetTokenTransfersRequest {
     fromBlock?: number | "latest" | "earliest";
     toBlock?: number | "latest" | "earliest";
     fromTimestamp?: number | "latest" | "earliest";


### PR DESCRIPTION

### **Description:**  
The interface was named `GetTransfersRequest`, but based on its structure and the naming convention of other interfaces, it should be `GetTokenTransfersRequest` to match `GetTokenTransfersReply`.  
